### PR TITLE
Include boost's is_reference.hpp and link against CMAKE_DL_LIBS

### DIFF
--- a/src/nc/common/CheckedCast.h
+++ b/src/nc/common/CheckedCast.h
@@ -31,6 +31,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_polymorphic.hpp>
 #include <boost/type_traits/is_pointer.hpp>
+#include <boost/type_traits/is_reference.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/mpl/and.hpp>
 

--- a/src/nocode/CMakeLists.txt
+++ b/src/nocode/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOURCES
 )
 
 add_executable(nocode ${SOURCES})
-target_link_libraries(nocode nc-core ${Boost_LIBRARIES} ${QT_LIBRARIES})
+target_link_libraries(nocode nc-core ${Boost_LIBRARIES} ${QT_LIBRARIES} ${CMAKE_DL_LIBS})
 
 if (NOT ${IDA_PLUGIN_ENABLED})
     install(TARGETS nocode RUNTIME DESTINATION bin)

--- a/src/snowman/CMakeLists.txt
+++ b/src/snowman/CMakeLists.txt
@@ -16,7 +16,7 @@ if(MINGW)
 endif(MINGW)
 
 add_executable(snowman WIN32 ${RES_FILES} ${SOURCES})
-target_link_libraries(snowman nc-gui nc-core ${Boost_LIBRARIES} ${QT_LIBRARIES})
+target_link_libraries(snowman nc-gui nc-core ${Boost_LIBRARIES} ${QT_LIBRARIES} ${CMAKE_DL_LIBS})
 if(MSVC)
     set_target_properties(snowman PROPERTIES LINK_FLAGS /ENTRY:mainCRTStartup)
 endif()


### PR DESCRIPTION
This fixes a compile error (gcc complaining that is_reference is not
declared) with boost 1.60.0 (on Arch Linux).

The original error was:

```
snowman/src/nc/common/CheckedCast.h: In function ‘typename boost::enable_if<boost::is_polymorphic<From>, To>::type nc::checked_cast(From&)’:
snowman/src/nc/common/CheckedCast.h:90:23: error: ‘is_reference’ is not a member of ‘boost’
         static_assert(boost::is_reference<To>::value, "Target type must be a reference");
```
